### PR TITLE
Add Floating Navigation Sidebar to Admin Panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 coverage
 .nyc_output
+**/screenshots

--- a/cypress/e2e/spec-raffle-admin-page.cy.ts
+++ b/cypress/e2e/spec-raffle-admin-page.cy.ts
@@ -15,8 +15,71 @@ describe('Raffle Admin Page', () => {
         cy.contains('h1', 'Raffle Management').should('be.visible');
     });
     
+    // New test for sidebar navigation
+    it('should have a sidebar with navigation options', () => {
+        // Check sidebar is visible
+        cy.contains('Raffle Admin').should('be.visible');
+        
+        // Check all navigation items exist
+        cy.contains('Winners').should('be.visible');
+        cy.contains('Metrics').should('be.visible');
+        cy.contains('Settings').should('be.visible');
+    });
+    
+    // New test for navigating between sections using sidebar
+    it('should navigate between sections when clicking sidebar items', () => {
+        // Should start with Winners section visible
+        cy.contains('Raffle Winners').should('be.visible');
+        
+        // Navigate to Metrics section
+        cy.contains('Metrics').click();
+        cy.contains('Raffle Metrics Dashboard').should('be.visible');
+        cy.contains('Raffle Winners').should('not.exist');
+        
+        // Navigate to Settings section
+        cy.contains('Settings').click();
+        cy.contains('Raffle Settings').should('be.visible');
+        cy.contains('Raffle Metrics Dashboard').should('not.exist');
+        
+        // Go back to Winners section
+        cy.contains('Winners').click();
+        cy.contains('Raffle Winners').should('be.visible');
+        cy.contains('Raffle Settings').should('not.exist');
+    });
+    
+    // New test for Metrics section content
+    it('should display the metrics dashboard section', () => {
+        cy.contains('Metrics').click();
+        cy.contains('Raffle Metrics Dashboard').should('be.visible');
+        cy.contains('Metrics dashboard content will be displayed here').should('be.visible');
+    });
+    
+    // New test for Settings section content
+    it('should display the settings section', () => {
+        cy.contains('Settings').click();
+        cy.contains('Raffle Settings').should('be.visible');
+        cy.contains('Settings configuration options will be displayed here').should('be.visible');
+    });
+    
+    // Check that selected navigation item is highlighted
+    it('should highlight the active navigation item in the sidebar', () => {
+        // Winners should be selected by default
+        cy.contains('[data-cy=nav-Winners]', 'Winners').should('have.class', 'Mui-selected');
+        
+        // Click on Metrics and verify it becomes selected
+        cy.contains('Metrics').click();
+        cy.contains('[data-cy=nav-Metrics]', 'Metrics').should('have.class', 'Mui-selected');
+        cy.contains('[data-cy=nav-Winners]', 'Winners').should('not.have.class', 'Mui-selected');
+        
+        // Click on Settings and verify it becomes selected
+        cy.contains('Settings').click();
+        cy.contains('[data-cy=nav-Settings]', 'Settings').should('have.class', 'Mui-selected');
+        cy.contains('[data-cy=nav-Metrics]', 'Metrics').should('not.have.class', 'Mui-selected');
+    });
+    
     it('should display the winners table with correct columns', () => {
-        cy.contains('Winners List').should('be.visible');
+        // Make sure we're on the Winners section
+        cy.contains('Winners').click();
         
         // Check table headers
         cy.get('table th').eq(1).should('contain', 'Winner ID');

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/components/MetricsSection.tsx
+++ b/src/components/MetricsSection.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+const MetricsSection: React.FC = () => {
+  return (
+    <Box sx={{ my: 4 }}>
+      <Typography variant="h5" component="h2" gutterBottom>
+        Raffle Metrics Dashboard
+      </Typography>
+      <Typography variant="body1">
+        Metrics dashboard content will be displayed here.
+      </Typography>
+    </Box>
+  );
+};
+
+export default MetricsSection;

--- a/src/components/RaffleWinnersTable.tsx
+++ b/src/components/RaffleWinnersTable.tsx
@@ -7,7 +7,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Typography,
   Box,
   TableSortLabel,
 } from "@mui/material";
@@ -88,9 +87,6 @@ const RaffleWinnersTable: React.FC = () => {
   return (
     <>
       <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
-        <Typography variant="h5" component="h2" gutterBottom sx={{ mt: 1 }}>
-          Winners List
-        </Typography>
         <RaffleWinnersResetButton />
       </Box>
 

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+const SettingsSection: React.FC = () => {
+  return (
+    <Box sx={{ my: 4 }}>
+      <Typography variant="h5" component="h2" gutterBottom>
+        Raffle Settings
+      </Typography>
+      <Typography variant="body1">
+        Settings configuration options will be displayed here.
+      </Typography>
+    </Box>
+  );
+};
+
+export default SettingsSection;

--- a/src/components/WinnersSection.tsx
+++ b/src/components/WinnersSection.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import RaffleWinnersTable from "./RaffleWinnersTable";
+
+const WinnersSection: React.FC = () => {
+  return (
+    <Box sx={{ my: 4 }}>
+      <Typography variant="h5" component="h2" gutterBottom>
+        Raffle Winners
+      </Typography>
+      <RaffleWinnersTable />
+    </Box>
+  );
+};
+
+export default WinnersSection;

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -10,7 +10,6 @@ import {
   ListItemIcon,
   ListItemText,
   Divider,
-  styled,
 } from "@mui/material";
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -28,19 +27,6 @@ enum AdminView {
 
 // Sidebar width
 const drawerWidth = 240;
-
-// Create styled component for the main content
-const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
-  open?: boolean;
-}>(({ theme }) => ({
-  flexGrow: 1,
-  padding: theme.spacing(3),
-  marginLeft: drawerWidth,
-  transition: theme.transitions.create('margin', {
-    easing: theme.transitions.easing.sharp,
-    duration: theme.transitions.duration.leavingScreen,
-  }),
-}));
 
 const AdminPage: React.FC = () => {
   // State to track the active view

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -109,10 +109,7 @@ const AdminPage: React.FC = () => {
           ))}
         </List>
       </Drawer>
-      
-      {/* Main content area */}
-      <Main>
-        <Container maxWidth="lg">
+        <Container>
           <Box sx={{ my: 4 }}>
             <Typography variant="h4" component="h1" gutterBottom>
               Raffle Management
@@ -122,7 +119,6 @@ const AdminPage: React.FC = () => {
             </Box>
           </Box>
         </Container>
-      </Main>
     </Box>
   );
 };

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,22 +1,129 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Box,
   Typography,
   Container,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+  styled,
 } from "@mui/material";
-import RaffleWinnersTable from "../components/RaffleWinnersTable";
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import SettingsIcon from '@mui/icons-material/Settings';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import WinnersSection from "../components/WinnersSection";
+import MetricsSection from "../components/MetricsSection";
+import SettingsSection from "../components/SettingsSection";
+
+// Enum for navigation tabs
+enum AdminView {
+  WINNERS = "Winners",
+  METRICS = "Metrics",
+  SETTINGS = "Settings"
+}
+
+// Sidebar width
+const drawerWidth = 240;
+
+// Create styled component for the main content
+const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
+  open?: boolean;
+}>(({ theme }) => ({
+  flexGrow: 1,
+  padding: theme.spacing(3),
+  marginLeft: drawerWidth,
+  transition: theme.transitions.create('margin', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+}));
 
 const AdminPage: React.FC = () => {
-  return (
-    <Container maxWidth="lg">
-      <Box sx={{ my: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Raffle Management
-        </Typography>
+  // State to track the active view
+  const [activeView, setActiveView] = useState<AdminView>(AdminView.WINNERS);
 
-        <RaffleWinnersTable />
-      </Box>
-    </Container>
+  // Get the icon for each navigation item
+  const getNavIcon = (view: AdminView) => {
+    switch (view) {
+      case AdminView.WINNERS:
+        return <EmojiEventsIcon />;
+      case AdminView.METRICS:
+        return <BarChartIcon />;
+      case AdminView.SETTINGS:
+        return <SettingsIcon />;
+    }
+  };
+
+  // Render the active content section
+  const renderContent = () => {
+    switch (activeView) {
+      case AdminView.WINNERS:
+        return <WinnersSection />;
+      case AdminView.METRICS:
+        return <MetricsSection />;
+      case AdminView.SETTINGS:
+        return <SettingsSection />;
+      default:
+        return <WinnersSection />;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      {/* Persistent sidebar drawer */}
+      <Drawer
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+          },
+        }}
+        variant="permanent"
+        anchor="left"
+      >
+        <Box sx={{ p: 2 }}>
+          <Typography variant="h6" noWrap component="div">
+            Raffle Admin
+          </Typography>
+        </Box>
+        <Divider />
+        <List>
+          {Object.values(AdminView).map((view) => (
+            <ListItem key={view} disablePadding>
+              <ListItemButton 
+                selected={activeView === view}
+                onClick={() => setActiveView(view)}
+              >
+                <ListItemIcon>
+                  {getNavIcon(view)}
+                </ListItemIcon>
+                <ListItemText primary={view} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+      
+      {/* Main content area */}
+      <Main>
+        <Container maxWidth="lg">
+          <Box sx={{ my: 4 }}>
+            <Typography variant="h4" component="h1" gutterBottom>
+              Raffle Management
+            </Typography>
+            <Box sx={{ overflow: 'auto' }}>
+              {renderContent()}
+            </Box>
+          </Box>
+        </Container>
+      </Main>
+    </Box>
   );
 };
 

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -99,6 +99,7 @@ const AdminPage: React.FC = () => {
               <ListItemButton 
                 selected={activeView === view}
                 onClick={() => setActiveView(view)}
+                data-cy={`nav-${view}`}
               >
                 <ListItemIcon>
                   {getNavIcon(view)}


### PR DESCRIPTION
Closes #28 
This pull request introduces several new sections to the admin page and refactors existing components to improve the structure and functionality of the raffle management system. The most important changes include adding new sections for metrics and settings, creating a sidebar navigation for these sections, and refactoring the winners section.

New sections and components:

* [`src/components/MetricsSection.tsx`](diffhunk://#diff-913678809680f97d1abba618ee378f66077b9eb28295a2db4079d0c8c3daca8cR1-R17): Added a new `MetricsSection` component to display the raffle metrics dashboard.
* [`src/components/SettingsSection.tsx`](diffhunk://#diff-448a48ddc71e120e0f94b0b23303a26cae00b0aefcadf0177856ca2c5f377a9aR1-R17): Added a new `SettingsSection` component to manage raffle settings.
* [`src/components/WinnersSection.tsx`](diffhunk://#diff-779b28ae2e800c32324c7b237865a4376e5ead4a2e19a76de35c0bfa7ed08265R1-R16): Created a new `WinnersSection` component that includes the `RaffleWinnersTable`.

Navigation and layout improvements:

* [`src/pages/AdminPage.tsx`](diffhunk://#diff-733bad51a2e86c0fad3ea61e77fcd567182a3813c02c7a8909d220f0c4ff513cL1-R122): Introduced a sidebar navigation with tabs for "Winners", "Metrics", and "Settings". Added state management to track and render the active view.

Refactoring:

* [`src/components/RaffleWinnersTable.tsx`](diffhunk://#diff-618f4b841aaf8e6b28ea50ce404380d40f10677a062d88b1da733db24548fcd5L10): Removed the `Typography` header and adjusted the layout to fit within the new `WinnersSection` component. [[1]](diffhunk://#diff-618f4b841aaf8e6b28ea50ce404380d40f10677a062d88b1da733db24548fcd5L10) [[2]](diffhunk://#diff-618f4b841aaf8e6b28ea50ce404380d40f10677a062d88b1da733db24548fcd5L91-L93)