### PR TITLE
Move reset button to settings and add card color selector

### DIFF
--- a/cypress/e2e/spec-admin-settings.cy.ts
+++ b/cypress/e2e/spec-admin-settings.cy.ts
@@ -1,0 +1,113 @@
+describe('Admin Settings Page', () => {
+  beforeEach(() => {
+    cy.visit('/admin');
+    cy.contains('Settings').click();
+  });
+
+  it('should display the settings sections', () => {
+    cy.contains('Raffle Settings').should('be.visible');
+    cy.contains('Preferences').should('be.visible');
+    cy.contains('Advanced').should('be.visible');
+  });
+
+  it('should display and change winner card color preference', () => {
+    cy.get('[data-testid="card-color-select"]').should('be.visible');
+    cy.get('[data-testid="card-color-select"]').click();
+    cy.contains('Purple').click();
+    cy.get('[data-testid="card-color-select"]').should('contain.text', 'Purple');
+  });
+
+  it('should display load data and reset buttons in advanced section', () => {
+    cy.contains('Advanced').should('be.visible');
+    cy.get('[data-testid="load-data-button"]').should('be.visible');
+    cy.contains('Reset Raffle').should('be.visible');
+  });
+
+  it('should show reset confirmation dialog when clicking reset button', () => {
+    cy.contains('Reset Raffle').click();
+    cy.contains('Reset Raffle Data?').should('be.visible');
+    cy.contains('This action will permanently delete all winners and their prizes').should('be.visible');
+    cy.contains('button', 'Cancel').should('be.visible');
+    cy.contains('button', 'Reset').should('be.visible');
+  });
+
+  it('should cancel reset when clicking cancel', () => {
+    cy.contains('Reset Raffle').click();
+    cy.contains('button', 'Cancel').click();
+    cy.contains('Reset Raffle Data?').should('not.exist');
+  });
+
+  it('should reset raffle data when confirming reset', () => {
+    // First ensure we have some winners
+    cy.fixture('winners').then(winners => {
+      cy.window().then(win => {
+        win.localStorage.setItem('winners', JSON.stringify(winners));
+      });
+      cy.reload();
+      cy.contains('Settings').click();
+    });
+
+    // Perform reset
+    cy.contains('Reset Raffle').click();
+    cy.get('[data-testid="confirm-reset-button"]').click();
+
+    // Verify winners are cleared
+    cy.contains('Winners').click();
+    cy.contains('No winners recorded yet').should('be.visible');
+  });
+
+  describe('Theme Settings', () => {
+    beforeEach(() => {
+      // Clear any existing theme
+      cy.window().then(win => {
+        win.localStorage.removeItem('raffleWinnerCardTheme');
+      });
+      cy.reload();
+      cy.contains('Settings').click();
+    });
+
+    it('should persist theme selection to localStorage', () => {
+      // Select a theme
+      cy.get('[data-testid="card-color-select"]').click();
+      cy.contains('Royal Purple').click();
+
+      // Verify localStorage was updated
+      cy.window().then(win => {
+        const storedTheme = JSON.parse(win.localStorage.getItem('raffleWinnerCardTheme') || '{}');
+        expect(storedTheme.value).to.equal('purple');
+        expect(storedTheme.color).to.equal('#7b1fa2');
+      });
+
+      // Reload page and verify theme persists
+      cy.reload();
+      cy.contains('Settings').click();
+      cy.get('[data-testid="card-color-select"]').should('have.text', 'Royal Purple');
+    });
+
+    it('should show color preview in dropdown', () => {
+      cy.get('[data-testid="card-color-select"]').click();
+      
+      // Verify each option has a color preview box
+      cy.contains('li', 'Ocean Blue').find('div').should('have.css', 'background-color', 'rgb(25, 118, 210)');
+      cy.contains('li', 'Forest Green').find('div').should('have.css', 'background-color', 'rgb(46, 125, 50)');
+      cy.contains('li', 'Royal Purple').find('div').should('have.css', 'background-color', 'rgb(123, 31, 162)');
+    });
+
+    it('should apply theme color to winner cards', () => {
+      // Load some winners
+      cy.fixture('winners').then(winners => {
+        cy.window().then(win => {
+          win.localStorage.setItem('winners', JSON.stringify(winners));
+        });
+      });
+
+      // Select a theme
+      cy.get('[data-testid="card-color-select"]').click();
+      cy.contains('Ruby Red').click();
+
+      // Go to display page and verify card color
+      cy.visit('/display');
+      cy.get('.MuiCard-root').first().should('have.css', 'background-color', 'rgb(211, 47, 47)');
+    });
+  });
+});

--- a/cypress/e2e/spec-admin-settings.cy.ts
+++ b/cypress/e2e/spec-admin-settings.cy.ts
@@ -13,8 +13,8 @@ describe('Admin Settings Page', () => {
   it('should display and change winner card color preference', () => {
     cy.get('[data-testid="card-color-select"]').should('be.visible');
     cy.get('[data-testid="card-color-select"]').click();
-    cy.contains('Purple').click();
-    cy.get('[data-testid="card-color-select"]').should('contain.text', 'Purple');
+    cy.contains('Sunset Orange').click();
+    cy.get('[data-testid="card-color-select"]').should('contain.text', 'Sunset Orange');
   });
 
   it('should display load data and reset buttons in advanced section', () => {
@@ -67,15 +67,18 @@ describe('Admin Settings Page', () => {
     });
 
     it('should start with default white theme', () => {
-      cy.get('[data-testid="card-color-select"]').should('have.text', 'Default White');
+      cy.get('[data-testid="card-color-select"]').should('contain.text', 'Default White');
       
       // Visit display page and verify default white color
       cy.visit('/display');
+      cy.get('input').type('Test Winner');
+      cy.contains('button', 'Enter').click();
       cy.get('.MuiCard-root').first().should('have.css', 'background-color', 'rgb(255, 255, 255)');
     });
 
     it('should persist theme selection to localStorage', () => {
       // Select Sunset Orange theme
+      cy.get('[data-testid="card-color-select"]').should('be.visible');
       cy.get('[data-testid="card-color-select"]').click();
       cy.contains('Sunset Orange').click();
 
@@ -89,7 +92,7 @@ describe('Admin Settings Page', () => {
       // Reload page and verify theme persists
       cy.reload();
       cy.contains('Settings').click();
-      cy.get('[data-testid="card-color-select"]').should('have.text', 'Sunset Orange');
+      cy.get('[data-testid="card-color-select"]').contains('Sunset Orange').should('be.visible');
     });
 
     it('should show color preview in dropdown', () => {
@@ -114,6 +117,8 @@ describe('Admin Settings Page', () => {
 
       // Go to display page and verify card color
       cy.visit('/display');
+      cy.get('input').type('Test Winner');
+      cy.contains('button', 'Enter').click();
       cy.get('.MuiCard-root').first().should('have.css', 'background-color', 'rgb(237, 108, 2)');
     });
   });

--- a/cypress/e2e/spec-admin-settings.cy.ts
+++ b/cypress/e2e/spec-admin-settings.cy.ts
@@ -66,31 +66,38 @@ describe('Admin Settings Page', () => {
       cy.contains('Settings').click();
     });
 
+    it('should start with default white theme', () => {
+      cy.get('[data-testid="card-color-select"]').should('have.text', 'Default White');
+      
+      // Visit display page and verify default white color
+      cy.visit('/display');
+      cy.get('.MuiCard-root').first().should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    });
+
     it('should persist theme selection to localStorage', () => {
-      // Select a theme
+      // Select Sunset Orange theme
       cy.get('[data-testid="card-color-select"]').click();
-      cy.contains('Royal Purple').click();
+      cy.contains('Sunset Orange').click();
 
       // Verify localStorage was updated
       cy.window().then(win => {
         const storedTheme = JSON.parse(win.localStorage.getItem('raffleWinnerCardTheme') || '{}');
-        expect(storedTheme.value).to.equal('purple');
-        expect(storedTheme.color).to.equal('#7b1fa2');
+        expect(storedTheme.value).to.equal('sunset');
+        expect(storedTheme.color).to.equal('#ed6c02');
       });
 
       // Reload page and verify theme persists
       cy.reload();
       cy.contains('Settings').click();
-      cy.get('[data-testid="card-color-select"]').should('have.text', 'Royal Purple');
+      cy.get('[data-testid="card-color-select"]').should('have.text', 'Sunset Orange');
     });
 
     it('should show color preview in dropdown', () => {
       cy.get('[data-testid="card-color-select"]').click();
       
       // Verify each option has a color preview box
-      cy.contains('li', 'Ocean Blue').find('div').should('have.css', 'background-color', 'rgb(25, 118, 210)');
-      cy.contains('li', 'Forest Green').find('div').should('have.css', 'background-color', 'rgb(46, 125, 50)');
-      cy.contains('li', 'Royal Purple').find('div').should('have.css', 'background-color', 'rgb(123, 31, 162)');
+      cy.contains('li', 'Default White').find('div').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+      cy.contains('li', 'Sunset Orange').find('div').should('have.css', 'background-color', 'rgb(237, 108, 2)');
     });
 
     it('should apply theme color to winner cards', () => {
@@ -101,13 +108,13 @@ describe('Admin Settings Page', () => {
         });
       });
 
-      // Select a theme
+      // Select Sunset Orange theme
       cy.get('[data-testid="card-color-select"]').click();
-      cy.contains('Ruby Red').click();
+      cy.contains('Sunset Orange').click();
 
       // Go to display page and verify card color
       cy.visit('/display');
-      cy.get('.MuiCard-root').first().should('have.css', 'background-color', 'rgb(211, 47, 47)');
+      cy.get('.MuiCard-root').first().should('have.css', 'background-color', 'rgb(237, 108, 2)');
     });
   });
 });

--- a/cypress/e2e/spec-raffle-admin-page.cy.ts
+++ b/cypress/e2e/spec-raffle-admin-page.cy.ts
@@ -15,7 +15,6 @@ describe('Raffle Admin Page', () => {
         cy.contains('h1', 'Raffle Management').should('be.visible');
     });
     
-    // New test for sidebar navigation
     it('should have a sidebar with navigation options', () => {
         // Check sidebar is visible
         cy.contains('Raffle Admin').should('be.visible');
@@ -26,7 +25,6 @@ describe('Raffle Admin Page', () => {
         cy.contains('Settings').should('be.visible');
     });
     
-    // New test for navigating between sections using sidebar
     it('should navigate between sections when clicking sidebar items', () => {
         // Should start with Winners section visible
         cy.contains('Raffle Winners').should('be.visible');
@@ -47,21 +45,19 @@ describe('Raffle Admin Page', () => {
         cy.contains('Raffle Settings').should('not.exist');
     });
     
-    // New test for Metrics section content
     it('should display the metrics dashboard section', () => {
         cy.contains('Metrics').click();
         cy.contains('Raffle Metrics Dashboard').should('be.visible');
         cy.contains('Metrics dashboard content will be displayed here').should('be.visible');
     });
     
-    // New test for Settings section content
     it('should display the settings section', () => {
         cy.contains('Settings').click();
         cy.contains('Raffle Settings').should('be.visible');
-        cy.contains('Settings configuration options will be displayed here').should('be.visible');
+        cy.contains('Preferences').should('be.visible');
+        cy.contains('Advanced').should('be.visible');
     });
     
-    // Check that selected navigation item is highlighted
     it('should highlight the active navigation item in the sidebar', () => {
         // Winners should be selected by default
         cy.contains('[data-cy=nav-Winners]', 'Winners').should('have.class', 'Mui-selected');
@@ -74,7 +70,7 @@ describe('Raffle Admin Page', () => {
         // Click on Settings and verify it becomes selected
         cy.contains('Settings').click();
         cy.contains('[data-cy=nav-Settings]', 'Settings').should('have.class', 'Mui-selected');
-        cy.contains('[data-cy=nav-Metrics]', 'Metrics').should('not.have.class', 'Mui-selected');
+        cy.contains('[data-cy=nav-Winners]', 'Winners').should('not.have.class', 'Mui-selected');
     });
     
     it('should display the winners table with correct columns', () => {
@@ -213,47 +209,6 @@ describe('Raffle Admin Page', () => {
             } else {
                 this.skip(); // Skip if no winners with unclaimed prizes
             }
-        });
-    });
-    
-    it('should open reset dialog when reset button is clicked', () => {
-        // Reset dialog should not be visible initially
-        cy.contains('Reset Raffle Data?').should('not.exist');
-        
-        // Click the Reset Raffle button
-        cy.contains('button', 'Reset Raffle').click();
-        
-        // Dialog should appear
-        cy.contains('Reset Raffle Data?').should('be.visible');
-        cy.contains('This action will permanently delete all winners and their prizes').should('be.visible');
-        
-        // Cancel button should close dialog
-        cy.contains('button', 'Cancel').click();
-        cy.contains('Reset Raffle Data?').should('not.exist');
-    });
-    
-    it('should clear all winners when reset is confirmed', () => {
-        // First check we have winners
-        cy.get('table tbody tr').should('have.length.at.least', 1);
-        
-        // Click the Reset Raffle button
-        cy.contains('button', 'Reset Raffle').click();
-        
-        // Confirm the reset
-        cy.get('[data-testid=confirm-reset-button]').click();
-        
-        // Table should now show no winners
-        cy.contains('No winners recorded yet').should('be.visible');
-        
-        // LocalStorage should be cleared
-        cy.getLocalStorage('raffleWinners').then(winners => {
-            if (!winners) {
-                expect.fail('raffleWinners key not found in localStorage');
-            }
-
-            const parsed = JSON.parse(winners);
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            expect(parsed).to.be.empty;
         });
     });
     

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import { CssBaseline, ThemeProvider, Box } from "@mui/material";
+import { CssBaseline, ThemeProvider as MuiThemeProvider, Box } from "@mui/material";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import RaffleDisplayPage from "./pages/RaffleDisplayPage";
 import AdminPage from "./pages/AdminPage";
 import { RaffleContextProvider } from "./providers/RaffleContextProvider";
 import { StorageContextProvider } from "./providers/StorageContextProvider";
+import { ThemeProvider } from "./providers/ThemeProvider";
 import { WinnersList } from "./classes/winnersList";
 import { theme } from "./theme";
 import { NavigationToggle } from "./components/NavigationToggle";
@@ -14,21 +15,23 @@ function App() {
   return (
     <StorageContextProvider>
       <RaffleContextProvider winnersList={winnersList}>
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          <BrowserRouter basename="/nppf-raffle-display">
-            <Box sx={{ position: 'relative' }}>
-              <Routes>
-                <Route path="/" element={<Navigate to="/display" />} />
-                <Route path="/admin" element={<AdminPage />} />
-                <Route
-                  path="/display"
-                  element={<RaffleDisplayPage title="General Raffle Winners" />}
-                />
-              </Routes>
-              <NavigationToggle />
-            </Box>
-          </BrowserRouter>
+        <ThemeProvider>
+          <MuiThemeProvider theme={theme}>
+            <CssBaseline />
+            <BrowserRouter basename="/nppf-raffle-display">
+              <Box sx={{ position: 'relative' }}>
+                <Routes>
+                  <Route path="/" element={<Navigate to="/display" />} />
+                  <Route path="/admin" element={<AdminPage />} />
+                  <Route
+                    path="/display"
+                    element={<RaffleDisplayPage title="General Raffle Winners" />}
+                  />
+                </Routes>
+                <NavigationToggle />
+              </Box>
+            </BrowserRouter>
+          </MuiThemeProvider>
         </ThemeProvider>
       </RaffleContextProvider>
     </StorageContextProvider>

--- a/src/components/RaffleWinner.tsx
+++ b/src/components/RaffleWinner.tsx
@@ -1,9 +1,31 @@
 import React from "react";
-import { Card, CardContent, Typography, Box, CardActionArea } from "@mui/material";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  CardActionArea,
+} from "@mui/material";
 import { Redeem as PresentIcon } from "@mui/icons-material";
 import { Winner } from "../types/winner";
 import { getUnclaimedPrizes } from "../utilities/raffle";
+import { useThemeContext } from "../contexts/ThemeContext";
 import { Prize } from "../types/prize";
+
+// Calculate whether to use black or white text based on background color
+const getTextColor = (bgColor: string) => {
+  // Convert hex to RGB
+  const hex = bgColor.replace('#', '');
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  
+  // Calculate relative luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  
+  // Use white text for dark backgrounds, black text for light backgrounds
+  return luminance > 0.5 ? '#000000' : '#ffffff';
+};
 
 interface RaffleWinnerProps {
   winner: Winner;
@@ -11,7 +33,7 @@ interface RaffleWinnerProps {
 }
 
 const RaffleWinnerPrizeIcon: React.FC = () => {
-  return <PresentIcon fontSize="large" color="primary" sx={{ ml: 1 }} />;
+  return <PresentIcon fontSize="large" color="inherit" sx={{ ml: 1 }} />;
 };
 
 const RaffleWinnerPrizesIcons: React.FC<{ unclaimedPrizes: Array<Prize> }> = ({
@@ -25,17 +47,23 @@ const RaffleWinnerPrizesIcons: React.FC<{ unclaimedPrizes: Array<Prize> }> = ({
 );
 
 const RaffleWinner: React.FC<RaffleWinnerProps> = ({ winner, onClick }) => {
-  // Generate present icons based on the number of unclaimed prizes
+  const { selectedTheme } = useThemeContext();
   const unclaimedPrizes = getUnclaimedPrizes(winner);
+  const textColor = getTextColor(selectedTheme.color);
 
   return (
     <Card
       sx={{
-        minWidth: 550, // Doubled from ~275
+        minWidth: 550,
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        boxShadow: 5, // Slightly increased shadow for larger card
+        boxShadow: 5,
+        bgcolor: selectedTheme.color,
+        color: textColor,
+        '& .MuiCardActionArea-root:hover': {
+          bgcolor: `${selectedTheme.color}ee`
+        }
       }}
     >
       <CardActionArea
@@ -53,8 +81,8 @@ const RaffleWinner: React.FC<RaffleWinnerProps> = ({ winner, onClick }) => {
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            py: 4, // Increased padding on top and bottom
-            px: 3, // Increased padding on sides
+            py: 4,
+            px: 3,
           }}
         >
           <Box
@@ -67,7 +95,7 @@ const RaffleWinner: React.FC<RaffleWinnerProps> = ({ winner, onClick }) => {
             }}
           >
             <Typography
-              variant="h2" // Increased from h4 to h2
+              variant="h2"
               component="div"
               sx={{
                 fontWeight: "bold",

--- a/src/components/RaffleWinner.tsx
+++ b/src/components/RaffleWinner.tsx
@@ -50,6 +50,7 @@ const RaffleWinner: React.FC<RaffleWinnerProps> = ({ winner, onClick }) => {
   const { selectedTheme } = useThemeContext();
   const unclaimedPrizes = getUnclaimedPrizes(winner);
   const textColor = getTextColor(selectedTheme.color);
+  const isWhiteTheme = selectedTheme.value === 'default';
 
   return (
     <Card
@@ -61,8 +62,9 @@ const RaffleWinner: React.FC<RaffleWinnerProps> = ({ winner, onClick }) => {
         boxShadow: 5,
         bgcolor: selectedTheme.color,
         color: textColor,
+        border: isWhiteTheme ? '1px solid rgba(0, 0, 0, 0.12)' : 'none',
         '& .MuiCardActionArea-root:hover': {
-          bgcolor: `${selectedTheme.color}ee`
+          bgcolor: isWhiteTheme ? 'rgba(0, 0, 0, 0.04)' : `${selectedTheme.color}ee`
         }
       }}
     >

--- a/src/components/RaffleWinnersGrid.tsx
+++ b/src/components/RaffleWinnersGrid.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Grid } from '@mui/material';
 import RaffleWinner from './RaffleWinner';
 import { getWinnersWithUnclaimedPrizes } from '../utilities/raffle';
 import { useRaffleWinners } from '../hooks/useRaffleWinners';
 import { ClaimSource } from '../types/claim';
+import { useThemeContext } from '../contexts/ThemeContext';
 
 interface WinnersGridProps {
   children?: never;
@@ -11,26 +12,28 @@ interface WinnersGridProps {
 
 const RaffleWinnersGrid: React.FC<WinnersGridProps> = () => {
   const {winners, recordClaim} = useRaffleWinners();
+  const { selectedTheme } = useThemeContext();
   const winnersWithUnclaimedPrizes = getWinnersWithUnclaimedPrizes(winners);
 
   // Calculate the grid sizing based on number of winners
-  const getGridSize = () => {
+  const getGridSize = useCallback(() => {
     const count = winners.length;
     if (count <= 3) return 12; // 1 per row for 1-3 winners
     if (count <= 6) return 6;  // 2 per row for 4-6 winners
     if (count <= 12) return 4; // 3 per row for 7-12 winners
     return 3; // 4 per row for 13+ winners
-  };
+  }, [winners.length]);
 
   const gridSize = getGridSize();
 
   return (
-    <Grid container spacing={3}>
+    <Grid container spacing={3} sx={{ backgroundColor: selectedTheme.color + '11' }}>
       {winnersWithUnclaimedPrizes.map((winner) => (
         <Grid item xs={12} sm={6} md={gridSize} key={winner.id}>
-          <RaffleWinner winner={winner} onClick={() => {
-            recordClaim(winner.id, ClaimSource.DISPLAY);
-          }}/>
+          <RaffleWinner 
+            winner={winner} 
+            onClick={() => recordClaim(winner.id, ClaimSource.DISPLAY)}
+          />
         </Grid>
       ))}
     </Grid>

--- a/src/components/RaffleWinnersTable.tsx
+++ b/src/components/RaffleWinnersTable.tsx
@@ -7,12 +7,10 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Box,
   TableSortLabel,
 } from "@mui/material";
 import { useRaffleWinners } from "../hooks/useRaffleWinners";
 import RaffleWinnerTableRow from "./RaffleWinnerTableRow";
-import RaffleWinnersResetButton from "./RaffleWinnersResetButton";
 import RaffleWinnersTableSearch, {
   StatusFilter,
 } from "./RaffleWinnersTableSearch";
@@ -86,10 +84,6 @@ const RaffleWinnersTable: React.FC = () => {
 
   return (
     <>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
-        <RaffleWinnersResetButton />
-      </Box>
-
       <RaffleWinnersTableSearch
         searchTerm={searchTerm}
         onSearchChange={setSearchTerm}

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -1,15 +1,76 @@
 import React from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Divider, Button, Select, MenuItem, FormControl, InputLabel } from "@mui/material";
+import { UploadFile as UploadIcon } from "@mui/icons-material";
+import RaffleWinnersResetButton from "./RaffleWinnersResetButton";
+import { useThemeContext } from "../contexts/ThemeContext";
 
 const SettingsSection: React.FC = () => {
+  const { selectedTheme, setSelectedTheme, themeOptions } = useThemeContext();
+
   return (
     <Box sx={{ my: 4 }}>
       <Typography variant="h5" component="h2" gutterBottom>
         Raffle Settings
       </Typography>
-      <Typography variant="body1">
-        Settings configuration options will be displayed here.
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h6" component="h3" gutterBottom>
+          Preferences
+        </Typography>
+        <FormControl sx={{ minWidth: 200 }}>
+          <InputLabel id="card-color-label">Winner Card Color</InputLabel>
+          <Select
+            labelId="card-color-label"
+            id="card-color-select"
+            value={selectedTheme.value}
+            label="Winner Card Color"
+            onChange={(e) => {
+              const theme = themeOptions.find(t => t.value === e.target.value);
+              if (theme) setSelectedTheme(theme);
+            }}
+            data-testid="card-color-select"
+          >
+            {themeOptions.map((option) => (
+              <MenuItem 
+                key={option.value} 
+                value={option.value}
+                sx={{ 
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: 1,
+                    backgroundColor: option.color
+                  }}
+                />
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      <Divider sx={{ my: 4 }} />
+      
+      <Typography variant="h6" component="h3" gutterBottom color="error">
+        Advanced
       </Typography>
+      <Box sx={{ mt: 2, display: 'flex', gap: 2 }}>
+        <RaffleWinnersResetButton variant="outlined" />
+        <Button
+          variant="outlined"
+          color="primary"
+          startIcon={<UploadIcon />}
+          data-testid="load-data-button"
+        >
+          Load Data
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+
+export interface ThemeOption {
+  label: string;
+  value: string;
+  color: string;
+}
+
+export interface ThemeContextType {
+  selectedTheme: ThemeOption;
+  setSelectedTheme: (theme: ThemeOption) => void;
+  themeOptions: ThemeOption[];
+}
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useThemeContext = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useThemeContext must be used within a ThemeProvider");
+  }
+  return context;
+};

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from "react";
+import { ThemeContext, ThemeOption } from "../contexts/ThemeContext";
+
+const themeOptions: ThemeOption[] = [
+  { label: "Ocean Blue", value: "ocean", color: "#1976d2" },
+  { label: "Forest Green", value: "forest", color: "#2e7d32" },
+  { label: "Royal Purple", value: "purple", color: "#7b1fa2" },
+  { label: "Sunset Orange", value: "sunset", color: "#ed6c02" },
+  { label: "Ruby Red", value: "ruby", color: "#d32f2f" }
+];
+
+const THEME_STORAGE_KEY = 'raffleWinnerCardTheme';
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedTheme, setSelectedTheme] = useState<ThemeOption>(() => {
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    if (storedTheme) {
+      try {
+        return JSON.parse(storedTheme);
+      } catch {
+        return themeOptions[0];
+      }
+    }
+    return themeOptions[0];
+  });
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(selectedTheme));
+  }, [selectedTheme]);
+
+  return (
+    <ThemeContext.Provider value={{ selectedTheme, setSelectedTheme, themeOptions }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -2,11 +2,8 @@ import React, { useState, useEffect } from "react";
 import { ThemeContext, ThemeOption } from "../contexts/ThemeContext";
 
 const themeOptions: ThemeOption[] = [
-  { label: "Ocean Blue", value: "ocean", color: "#1976d2" },
-  { label: "Forest Green", value: "forest", color: "#2e7d32" },
-  { label: "Royal Purple", value: "purple", color: "#7b1fa2" },
+  { label: "Default White", value: "default", color: "#ffffff" },
   { label: "Sunset Orange", value: "sunset", color: "#ed6c02" },
-  { label: "Ruby Red", value: "ruby", color: "#d32f2f" }
 ];
 
 const THEME_STORAGE_KEY = 'raffleWinnerCardTheme';


### PR DESCRIPTION
This pull request includes significant changes to the Cypress tests for the admin settings page, updates to the theme handling in the application, and improvements to the RaffleWinner component. The most important changes are as follows:

### Cypress Tests:
* Added comprehensive tests for the admin settings page, including tests for displaying settings sections, changing winner card color preference, and handling reset confirmation dialogs.
* Removed redundant comments in the `spec-raffle-admin-page.cy.ts` file to clean up the test descriptions and improve readability. [[1]](diffhunk://#diff-fd19342f20e240e2f5786641522f29bd646a44da7b12d2ff57e32903c1c5ebefL18) [[2]](diffhunk://#diff-fd19342f20e240e2f5786641522f29bd646a44da7b12d2ff57e32903c1c5ebefL29) [[3]](diffhunk://#diff-fd19342f20e240e2f5786641522f29bd646a44da7b12d2ff57e32903c1c5ebefL50-L64) [[4]](diffhunk://#diff-fd19342f20e240e2f5786641522f29bd646a44da7b12d2ff57e32903c1c5ebefL77-R73) [[5]](diffhunk://#diff-fd19342f20e240e2f5786641522f29bd646a44da7b12d2ff57e32903c1c5ebefL219-L259)

### Theme Handling:
* Introduced `ThemeContext` to manage theme selection and persistence, including a new `useThemeContext` hook.
* Updated `App.tsx` to use `MuiThemeProvider` and the new `ThemeProvider` for consistent theme management across the application. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L1-R7) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L17-R19) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R34)
* Enhanced the `SettingsSection` component to include a theme selection dropdown and added a reset button for advanced settings.

### RaffleWinner Component:
* Updated the `RaffleWinner` component to dynamically apply theme colors and calculate appropriate text colors based on the selected theme. [[1]](diffhunk://#diff-cf379e97ba5c4eaed6fefceb87569661d169ba67ffc7f1e69d04877f8f1d445aL2-R36) [[2]](diffhunk://#diff-cf379e97ba5c4eaed6fefceb87569661d169ba67ffc7f1e69d04877f8f1d445aL28-R68) [[3]](diffhunk://#diff-cf379e97ba5c4eaed6fefceb87569661d169ba67ffc7f1e69d04877f8f1d445aL56-R87) [[4]](diffhunk://#diff-cf379e97ba5c4eaed6fefceb87569661d169ba67ffc7f1e69d04877f8f1d445aL70-R100)

### RaffleWinnersGrid Component:
* Added theme context to the `RaffleWinnersGrid` component to apply background color based on the selected theme.

### Miscellaneous:
* Removed the `RaffleWinnersResetButton` from the `RaffleWinnersTable` component to streamline the layout. [[1]](diffhunk://#diff-618f4b841aaf8e6b28ea50ce404380d40f10677a062d88b1da733db24548fcd5L10-L15) [[2]](diffhunk://#diff-618f4b841aaf8e6b28ea50ce404380d40f10677a062d88b1da733db24548fcd5L89-L92)

Closed #31 #29 