### PR TITLE
Add script to copy index.html for specific routes during build process

### DIFF
--- a/copyRoutes.js
+++ b/copyRoutes.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+// Routes that need their own HTML files
+const routes = [
+  'display',
+  'admin'
+];
+
+// Path to the build directory
+const buildDir = path.join(__dirname, 'dist');
+
+// Read the built index.html file
+const indexPath = path.join(buildDir, 'index.html');
+const indexContent = fs.readFileSync(indexPath, 'utf8');
+
+// Create directories and copy index.html for each route
+routes.forEach(route => {
+  const routeDir = path.join(buildDir, route);
+  
+  // Create the directory if it doesn't exist
+  if (!fs.existsSync(routeDir)) {
+    fs.mkdirSync(routeDir, { recursive: true });
+  }
+  
+  // Create index.html in the route directory
+  const routeIndexPath = path.join(routeDir, 'index.html');
+  fs.writeFileSync(routeIndexPath, indexContent);
+  
+  console.log(`Created: ${routeIndexPath}`);
+});
+
+console.log('Route HTML files created successfully!');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node copyRoutes.js",
     "lint": "eslint .",
     "test": "start-server-and-test dev http://localhost:5173 cy:run && npm run cov:report",
     "preview": "vite preview"


### PR DESCRIPTION
This pull request includes changes to automate the creation of HTML files for specific routes and updates the build process to include this automation.

### Automation of HTML file creation for routes:

* [`copyRoutes.js`](diffhunk://#diff-f67181278ddd5a9fdf753476715ecac14e9812d97e62e543df1691d8204ce080R1-R33): Added a new script that reads the built `index.html` file, creates directories for specified routes if they do not exist, and copies `index.html` into these directories. The script logs the creation of each route's HTML file.

### Update to the build process:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10): Modified the `build` script to include the execution of the `copyRoutes.js` script after building with `tsc` and `vite`.